### PR TITLE
sis-extras 0.1.3 :snowflake:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # sis-extras-feedstock
+
+home: https://github.com/blackary/sis-extras
+summary: Python package to make it easy to develop beautiful, performant streamlit-in-snowflake apps
+description: |
+  The sis-extras package provides a set of Python utilities designed
+  to help you develop beautiful, performant streamlit-in-snowflake
+  apps.
+license: MIT
+license_url: https://spdx.org/licenses/MIT.html
+license_family: MIT
+doc_url: https://github.com/blackary/sis-extras
+dev_url: https://github.com/blackary/sis-extras

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # sis-extras-feedstock
 
 home: https://github.com/blackary/sis-extras
+
 summary: Python package to make it easy to develop beautiful, performant streamlit-in-snowflake apps
+
 description: |
-  The sis-extras package provides a set of Python utilities designed
-  to help you develop beautiful, performant streamlit-in-snowflake
-  apps.
+	The sis-extras package provides a set of Python utilities designed
+	to help you develop beautiful, performant streamlit-in-snowflake
+	apps.
+
 license: MIT
+
 license_url: https://spdx.org/licenses/MIT.html
+
 license_family: MIT
+
 doc_url: https://github.com/blackary/sis-extras
+
 dev_url: https://github.com/blackary/sis-extras

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ about:
     to help you develop beautiful, performant streamlit-in-snowflake
     apps.
   license: MIT
-  license_url: https://spdx.org/licenses/MIT.html
+  license_file: LICENSE.txt
   license_family: MIT
   doc_url: https://github.com/blackary/sis-extras
   dev_url: https://github.com/blackary/sis-extras

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,5 +66,3 @@ about:
 extra:
   recipe-maintainers:
     - ifitchet
-  skip-lints:
-    - missing_pip_check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,9 @@ test:
     - pytest
   commands:
     #- pip check
-    - pytest -v tests -k "not test_example_app.py"
+    # test_example_app.py is picked by win-64 and gets an AppTest
+    # timeout
+    - pytest -v tests/test_sis_extras.py
 
 about:
   home: https://github.com/blackary/sis-extras
@@ -55,3 +57,5 @@ about:
 extra:
   recipe-maintainers:
     - ifitchet
+  skip-lints:
+    - missing_pip_check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,11 +8,14 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sis_extras-{{ version }}.tar.gz
   sha256: e7e1892ab5eef36e38880dc9b636597dce83162df4d51f3f7f509a7e792e8a73
+  patches:
+    - patches/0001-loosen-Python-and-streamlit-constraints.patch
 
 build:
-  skip: True  # [py>38]
+  # Strictly, upstream is py==38 and we don't have
+  # snowflake-snowpark-python for 3.12
   # no streamlit on s390x
-  skip: True  # [s390x]
+  skip: True  # [py>311 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
@@ -23,7 +26,8 @@ requirements:
     - pip
   run:
     - python
-    - streamlit # ==1.31.1
+    # Strictly, upstream is streamlit==1.31.1
+    - streamlit
     - snowflake-snowpark-python >=1.13.0
     - plotly >=5.20.0
 
@@ -35,11 +39,12 @@ test:
   requires:
     - pip
     - pytest
+    # sqlparse can be used if available
+    - sqlparse
   commands:
-    #- pip check
-    # test_example_app.py is picked by win-64 and gets an AppTest
-    # timeout
+    - pip check
     - pytest -v tests/test_sis_extras.py
+    - python -m tests.test_example_app
 
 about:
   home: https://github.com/blackary/sis-extras

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "sis-extras" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sis_extras-{{ version }}.tar.gz
+  sha256: e7e1892ab5eef36e38880dc9b636597dce83162df4d51f3f7f509a7e792e8a73
+
+build:
+  skip: True  # [py>38]
+  # no streamlit on s390x
+  skip: True  # [s390x]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pdm-backend
+    - pip
+  run:
+    - python
+    - streamlit # ==1.31.1
+    - snowflake-snowpark-python >=1.13.0
+    - plotly >=5.20.0
+
+test:
+  source_files:
+    - tests
+  imports:
+    - sis_extras
+  requires:
+    - pip
+    - pytest
+  commands:
+    #- pip check
+    - pytest -v tests
+
+about:
+  home: https://github.com/blackary/sis-extras
+  summary: Python package to make it easy to develop beautiful, performant streamlit-in-snowflake apps
+  description: |
+    The sis-extras package provides a set of Python utilities designed
+    to help you develop beautiful, performant streamlit-in-snowflake
+    apps.
+  license: MIT
+  license_url: https://spdx.org/licenses/MIT.html
+  license_family: MIT
+  doc_url: https://github.com/blackary/sis-extras
+  dev_url: https://github.com/blackary/sis-extras
+
+extra:
+  recipe-maintainers:
+    - ifitchet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,12 +8,12 @@ package:
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sis_extras-{{ version }}.tar.gz
     sha256: e7e1892ab5eef36e38880dc9b636597dce83162df4d51f3f7f509a7e792e8a73
+    patches:
+      - patches/0001-loosen-Python-and-streamlit-constraints.patch
+      - patches/0002-add-a-timeout-to-the-test-run.patch
   # We requested this license file be added for future releases
   - url: https://raw.githubusercontent.com/blackary/sis-extras/01190913ea267bf341233d208274a3e93e0d2260/LICENSE.txt
     sha256: a473df6c7b1f1b6a77ac47c18c658aee8bb1b95c018cd56dee688496c3c85728
-  - patches:
-      - patches/0001-loosen-Python-and-streamlit-constraints.patch
-      - patches/0002-add-a-timeout-to-the-test-run.patch
 
 build:
   # Strictly, upstream is py==38 and we don't have

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - pytest
   commands:
     #- pip check
-    - pytest -v tests
+    - pytest -v tests -k "not test_example_app.py"
 
 about:
   home: https://github.com/blackary/sis-extras

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: e7e1892ab5eef36e38880dc9b636597dce83162df4d51f3f7f509a7e792e8a73
   patches:
     - patches/0001-loosen-Python-and-streamlit-constraints.patch
+    - patches/0002-add-a-timeout-to-the-test-run.patch
 
 build:
   # Strictly, upstream is py==38 and we don't have
@@ -20,6 +21,9 @@ build:
   number: 0
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pdm-backend

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,14 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sis_extras-{{ version }}.tar.gz
-  sha256: e7e1892ab5eef36e38880dc9b636597dce83162df4d51f3f7f509a7e792e8a73
-  patches:
-    - patches/0001-loosen-Python-and-streamlit-constraints.patch
-    - patches/0002-add-a-timeout-to-the-test-run.patch
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sis_extras-{{ version }}.tar.gz
+    sha256: e7e1892ab5eef36e38880dc9b636597dce83162df4d51f3f7f509a7e792e8a73
+  # We requested this license file be added for future releases
+  - url: https://raw.githubusercontent.com/blackary/sis-extras/01190913ea267bf341233d208274a3e93e0d2260/LICENSE.txt
+    sha256: a473df6c7b1f1b6a77ac47c18c658aee8bb1b95c018cd56dee688496c3c85728
+  - patches:
+      - patches/0001-loosen-Python-and-streamlit-constraints.patch
+      - patches/0002-add-a-timeout-to-the-test-run.patch
 
 build:
   # Strictly, upstream is py==38 and we don't have

--- a/recipe/patches/0001-loosen-Python-and-streamlit-constraints.patch
+++ b/recipe/patches/0001-loosen-Python-and-streamlit-constraints.patch
@@ -1,0 +1,30 @@
+From 9cb2ea7d97f96b5d5d597e2023f7adef14b68d91 Mon Sep 17 00:00:00 2001
+From: Ian Fitchet <ifitchet@anaconda.com>
+Date: Mon, 1 Jul 2024 11:25:20 +0100
+Subject: [PATCH] loosen Python and streamlit constraints
+
+---
+ pyproject.toml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index ca3242f..a9dde5f 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,11 +6,11 @@ authors = [
+     { name = "Zachary Blackwood", email = "zblackwo@gmail.com" },
+ ]
+ dependencies = [
+-    "streamlit==1.31.1",
++    "streamlit>=1.31.1",
+     "snowflake-snowpark-python>=1.13.0",
+     "plotly>=5.20.0",
+ ]
+-requires-python = "==3.8.*"
++requires-python = ">=3.8"
+ readme = "README.md"
+ classifiers = [
+     "License :: OSI Approved :: MIT License",
+-- 
+2.39.3 (Apple Git-146)
+

--- a/recipe/patches/0002-add-a-timeout-to-the-test-run.patch
+++ b/recipe/patches/0002-add-a-timeout-to-the-test-run.patch
@@ -1,0 +1,26 @@
+From 8e5f4e5aba4956997df5474ddd35bf06c6373bd9 Mon Sep 17 00:00:00 2001
+From: Ian Fitchet <ifitchet@anaconda.com>
+Date: Mon, 1 Jul 2024 13:49:44 +0100
+Subject: [PATCH] add a timeout to the test run
+
+---
+ tests/test_example_app.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tests/test_example_app.py b/tests/test_example_app.py
+index 31e3504..20475f5 100644
+--- a/tests/test_example_app.py
++++ b/tests/test_example_app.py
+@@ -2,7 +2,8 @@ from streamlit.testing.v1 import AppTest
+ 
+ at = AppTest.from_file("example_app_formatting.py")
+ 
+-at.run()
++# win-64 times out after 3s
++at.run(timeout=30)
+ 
+ assert not at.exception
+ 
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
sis-extras 0.1.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4961]
- dev_url:        https://github.com/blackary/sis-extras/tree/v0.1.3
- conda_forge:    None
- pypi:           https://pypi.org/project/sis-extras/0.1.3
- pypi inspector: https://inspector.pypi.io/project/sis-extras/0.1.3

### Explanation of changes:

- basic recipe plus upstream tests
  - the upstream says it uses an MIT license (see `pyproject.toml`) but doesn't supply a file so I've used `license_url` to point at the spdx.org site
  - this is tied to `py=38` **only**
  - this is meant to be tied to `streamlit==1.31.1` but we are using `1.32.0` on `main`
    - this means disabling `pip check` (unless we patch the pinnings everywhere)
    - and keeping the linter quiet
- there are nominally two tests but `pytest` only discovers the one
  - the other is in a non-standard format?
  - uh, although `win-64` manages to choose it and then fail...
- updated `README` with `about:` section from `meta.yaml`
- pulled in the `LICENSE.txt` directly from a PR we asked for (but obviously not in this release)


[PKG-4961]: https://anaconda.atlassian.net/browse/PKG-4961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ